### PR TITLE
ci: enable integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run tests
-        run: cargo test
+        run: cargo test --features in-github-ci
   build:
     runs-on: ubuntu-latest
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run tests
-        run: cargo test --verbose --lib
+        run: cargo test
   build:
     runs-on: ubuntu-latest
     needs: test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,8 @@ name = "osm-transform"
 version = "0.3.2"
 edition = "2021"
 
+[features]
+in-github-ci = []
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [profile.dev]

--- a/src/area.rs
+++ b/src/area.rs
@@ -1,7 +1,7 @@
-use fs::create_dir;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fs;
+use std::fs::create_dir_all;
 use std::fs::File;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
@@ -9,7 +9,7 @@ use std::string::String;
 
 use btreemultimap::BTreeMultiMap;
 use csv::{ReaderBuilder, WriterBuilder};
-use geo::{BoundingRect, Contains, Coord, coord, Intersects, MultiPolygon, Rect, HasDimensions};
+use geo::{BoundingRect, Contains, Coord, coord, HasDimensions, Intersects, MultiPolygon, Rect};
 use geo::BooleanOps;
 use log::{debug, log_enabled, trace, warn};
 use log::Level::Trace;
@@ -19,8 +19,8 @@ use serde::{Deserialize, Serialize};
 use wkt::{Geometry, ToWkt};
 use wkt::Wkt;
 
-use crate::handler::{Handler, HandlerData};
 use crate::{get_directory_as_absolute_path, validate_file};
+use crate::handler::{Handler, HandlerData};
 
 const AREA_ID_MULTIPLE: u16 = u16::MAX;
 
@@ -171,7 +171,7 @@ impl AreaMappingManager {
     pub(crate) fn save_area_records(&mut self, csv_path_buf: &PathBuf, mapping: &Mapping) {
         let tile_size = mapping.tile_size;
         let index_dir_name = self.get_index_dir_name(csv_path_buf, tile_size);
-        create_dir(&index_dir_name).expect(format!("failed to create index directory {}", index_dir_name).as_str());
+        create_dir_all(&index_dir_name).expect(format!("failed to create index directory {}", index_dir_name).as_str());
         let mut file_path: PathBuf = Path::new(&index_dir_name).join(self.info_file_suffix.clone());
         let file = File::create(file_path.clone()).expect("failed to create file");
         let _ = serde_yaml::to_writer(file, &mapping.meta_info());

--- a/src/handler/geotiff.rs
+++ b/src/handler/geotiff.rs
@@ -740,7 +740,7 @@ mod tests {
     use crate::{get_application_name};
 
     #[test]
-    #[ignore]
+    #[cfg_attr(feature = "in-github-ci", ignore)]
     fn test_find_geotiff_id_for_wgs84_coord_srtm_ma_hd() {
         let _ = SimpleLogger::new().init();
         let mut geotiff_loader = GeoTiffManager::with_file_patterns(vec!["test/srtm*.tif".to_string(), "test/region*.tif".to_string(), "test/*gmted*.tif".to_string()]);
@@ -885,7 +885,7 @@ mod tests {
         assert_eq!("test/region_heidelberg_mannheim.tif", geotiffs[0]);
     }
     #[test]
-    #[ignore]
+    #[cfg_attr(feature = "in-github-ci", ignore)]
     fn test_find_geotiff_id_for_wgs84_coord_ma_hd_srtm() {
         let _ = SimpleLogger::new().init();
         let mut geotiff_loader = GeoTiffManager::new();

--- a/src/io.rs
+++ b/src/io.rs
@@ -102,7 +102,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore] //fixme - test does not work with cargo test
     fn process_files_verify_node_added() {
         let output = "test/baarle_small-mod.pbf".to_string();
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -74,7 +74,6 @@ fn run_minimal_write() {
 }
 #[test]
 fn run_all() {
-    let _ = fs::remove_dir_all("mapping_test_idx_0_40");
     let mut config = base_config();
     config.output_pbf = Some(PathBuf::from("target/tmp/output-integration-test-run_all.pbf"));
     config.country_data = Some(PathBuf::from("test/mapping_test.csv"));
@@ -99,7 +98,6 @@ fn run_all() {
 }
 #[test]
 fn run_country() {
-    let _ = fs::remove_dir_all("test/mapping_test_idx_0_40");
     let mut config = base_config();
     config.country_data = Some(PathBuf::from("test/mapping_test.csv"));
     config.country_tile_size = 0.4;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -73,6 +73,7 @@ fn run_minimal_write() {
     assert_eq!(&data.output_way_count, &FILTERED_WAY_COUNT);
 }
 #[test]
+#[cfg_attr(feature = "in-github-ci", ignore)]
 fn run_all() {
     let mut config = base_config();
     config.output_pbf = Some(PathBuf::from("target/tmp/output-integration-test-run_all.pbf"));
@@ -156,6 +157,7 @@ fn run_elevation() {
     assert_eq!(&data.output_way_count, &FILTERED_WAY_COUNT);
 }
 #[test]
+#[cfg_attr(feature = "in-github-ci", ignore)]
 fn run_elevation_way_splitting() {
     let mut config = base_config();
     config.elevation_tiffs = vec!["test/*.tif".to_string()];
@@ -171,6 +173,7 @@ fn run_elevation_way_splitting() {
     assert_eq!(&data.output_way_count, &FILTERED_WAY_COUNT);
 }
 #[test]
+#[cfg_attr(feature = "in-github-ci", ignore)]
 fn run_elevation_way_splitting_write() {
     let mut config = base_config();
     config.elevation_tiffs = vec!["test/*.tif".to_string()];


### PR DESCRIPTION
Run all tests in CI including integration tests except ones that require external GeoTIFF files.